### PR TITLE
Refactor: Typeprop codegen

### DIFF
--- a/Python/tier2.c
+++ b/Python/tier2.c
@@ -279,6 +279,32 @@ __type_propagate_TYPE_SET(
     }
 #endif
 
+    if (!src_is_new) {
+        // Check if they are the same tree
+        _Py_TYPENODE_t *srcrootref = src;
+        _Py_TYPENODE_t *dstrootref = dst;
+        uintptr_t dsttag = _Py_TYPENODE_GET_TAG(*dst);
+        uintptr_t srctag = _Py_TYPENODE_GET_TAG(*src);
+        switch (dsttag) {
+        case TYPE_REF: dstrootref = __typenode_get_rootptr(*dst);
+        case TYPE_ROOT:
+            switch (srctag) {
+            case TYPE_REF: srcrootref = __typenode_get_rootptr(*src);
+            case TYPE_ROOT:
+                if (srcrootref == dstrootref) {
+                    // Same tree, no point swapping
+                    return;
+                }
+                break;
+            default:
+                Py_UNREACHABLE();
+            }
+            break;
+        default:
+            Py_UNREACHABLE();
+        }
+    }
+
     uintptr_t tag = _Py_TYPENODE_GET_TAG(*dst);
     switch (tag) {
     case TYPE_ROOT: {

--- a/Python/tier2_typepropagator.c.h
+++ b/Python/tier2_typepropagator.c.h
@@ -412,7 +412,7 @@
         }
 
         TARGET(UNPACK_EX) {
-            STACK_GROW((oparg >> 8) + (oparg & 0xFF));
+            STACK_GROW((oparg & 0xFF) + (oparg >> 8));
             for (int i = 0; i < (oparg & 0xFF); i++) {TYPE_OVERWRITE((_Py_TYPENODE_t *)_Py_TYPENODE_NULLROOT, TYPESTACK_PEEK((oparg & 0xFF) - i), true);}
             break;
         }

--- a/Python/tier2_typepropagator.c.h
+++ b/Python/tier2_typepropagator.c.h
@@ -412,7 +412,7 @@
         }
 
         TARGET(UNPACK_EX) {
-            STACK_GROW((oparg & 0xFF) + (oparg >> 8));
+            STACK_GROW((oparg >> 8) + (oparg & 0xFF));
             for (int i = 0; i < (oparg & 0xFF); i++) {TYPE_OVERWRITE((_Py_TYPENODE_t *)_Py_TYPENODE_NULLROOT, TYPESTACK_PEEK((oparg & 0xFF) - i), true);}
             break;
         }

--- a/Tools/cases_generator/generate_cases.py
+++ b/Tools/cases_generator/generate_cases.py
@@ -13,8 +13,6 @@ import re
 import sys
 import typing
 
-from enum import Enum, auto
-
 import lexer as lx
 import parser
 from parser import StackEffect
@@ -495,8 +493,24 @@ class Instruction:
     def write_typeprop(self, out: Formatter) -> None:
         """Write one instruction's type propagation rules"""
 
-        # TODO: Add SWAP to DSL
+        # TODO: Detech TYPE_SWAP case
 
+        nullnode = "(_Py_TYPENODE_t *)_Py_TYPENODE_NULLROOT"
+        type_overwrite = "TYPE_OVERWRITE"
+        null = "NULL"
+        true_str = "true"
+        false_str = "false"
+        typenode_ptr = "_Py_TYPENODE_t *"
+        literal_root_format = "(_Py_TYPENODE_t *)_Py_TYPENODE_MAKE_ROOT((_Py_TYPENODE_t)&%s)"
+        typestackpeek_format = "TYPESTACK_PEEK(%s)"
+        typelocalsget_format = "TYPELOCALS_GET(%s)"
+        typeconstsget_format = "(_Py_TYPENODE_t *)TYPECONST_GET(%s)"
+
+        # Write type operations in reverse
+        ieffects = list(reversed(self.input_effects))
+        oeffects = list(reversed(self.output_effects))
+
+        # Get all input variables we need to declare
         need_to_declare = []
         # Stack input is used in local effect
         if self.local_effects and \
@@ -515,83 +529,72 @@ class Instruction:
                     continue
                 need_to_declare.append(src.name)
 
-        # Write input stack effect variable declarations and initializations
-        ieffects = list(reversed(self.input_effects))
-        usable_for_local_effect = {}
-        all_input_effect_names = {}
+        # Declare input variables
         for i, ieffect in enumerate(ieffects):
-
             if ieffect.name not in need_to_declare: continue
 
-            isize = string_effect_size(
-                list_effect_size([ieff for ieff in ieffects[: i + 1]])
-            )
-            all_input_effect_names[ieffect.name] = (ieffect, i)
-            dst = StackEffect(ieffect.name, "_Py_TYPENODE_t *")
+            isize = string_effect_size(list_effect_size(ieffects[: i + 1]))
+            dst = StackEffect(ieffect.name, typenode_ptr)
             if ieffect.size:
                 # TODO: Support more cases as needed
                 raise Exception("Type propagation across sized input effect not implemented")
             elif ieffect.cond:
-                src = StackEffect(f"({ieffect.cond}) ? TYPESTACK_PEEK({isize}) : NULL", "_Py_TYPENODE_t *")
+                src = StackEffect(f"({ieffect.cond}) ? {typestackpeek_format%isize} : {null}", typenode_ptr)
             else:
-                usable_for_local_effect[ieffect.name] = ieffect
-                src = StackEffect(f"TYPESTACK_PEEK({isize})", "_Py_TYPENODE_t *")
+                src = StackEffect(typestackpeek_format%isize, typenode_ptr)
             out.declare(dst, src)
 
-        # Write localarr effect
+        # Local effect
         if self.local_effects:
 
             idx = self.local_effects.index
             val = self.local_effects.value
 
-            typ_op = "TYPE_OVERWRITE"
-            dst = f"TYPELOCALS_GET({idx})"
+            dst = typelocalsget_format%idx
             match val:
-                case TypeSrcLiteral(name=valstr):
-                    if valstr == "NULL":
-                        src = "(_Py_TYPENODE_t *)_Py_TYPENODE_NULLROOT"
-                        flag = "true"
+                # Literal localeffect
+                case TypeSrcLiteral(literal=valstr):
+                    if valstr == null:
+                        src = null
+                        flag = true_str
                     else:
-                        src = f"(_Py_TYPENODE_t *)_Py_TYPENODE_MAKE_ROOT((_Py_TYPENODE_t)&{valstr})"
-                        flag = "true"
-                case TypeSrcStackInput(name=valstr):
-                    assert valstr in usable_for_local_effect, \
-                        "`cond` and `size` stackvar not supported for localeffect"
-                    src = valstr
-                    flag = "false"
-                # TODO: Support more cases as needed
-                case TypeSrcConst():
-                    raise Exception("Not implemented")
-                case TypeSrcLocals():
-                    raise Exception("Not implemented")
+                        src = literal_root_format%valstr
+                        flag = true_str
+                # Input localeffect
+                case TypeSrcStackInput(name=src):
+                    flag = false_str
                 case _:
                     typing.assert_never(val)
-            out.emit(f"{typ_op}({src}, {dst}, {flag});")
+            out.emit(f"{type_overwrite}({src}, {dst}, {flag});")
 
-        # Update stack size
-        out.stack_adjust(
-            0,
-            [ieff for ieff in self.input_effects],
-            [oeff for oeff in self.output_effects],
-        )
+        # Adjust stack size
+        out.stack_adjust(0, self.input_effects, oeffects)
+
+        # Pad ieffects to be the same length as oeffects
+        ieffects = ieffects[-len(oeffects):]
+        ieffects = [None]*(len(oeffects) - len(ieffects)) + ieffects
 
         # Stack effect
-        oeffects = list(reversed(self.output_effects))
-        for i, oeffect in enumerate(oeffects):
-            osize = string_effect_size(
-                list_effect_size([oeff for oeff in oeffects[: i + 1]])
-            )
-            dst = f"TYPESTACK_PEEK({osize})"
+        for i, (ieffect, oeffect) in enumerate(zip(ieffects, oeffects)):
 
-            # Check if it's even used
+            # Unused var
             if oeffect.name == UNUSED: continue
+            
+            otype = oeffect.type_annotation
+            osize = string_effect_size(list_effect_size(oeffects[: i + 1]))
+            dst = typestackpeek_format%osize
 
-            # For now assume OVERWRITE with NULL
-            if oeffect.size:
-                op = "TYPE_OVERWRITE"
-                src = "(_Py_TYPENODE_t *)_Py_TYPENODE_NULLROOT"
-                flag = "true"
-                dst = f"TYPESTACK_PEEK({osize} - i)"
+            # Unmoved var
+            if (otype is None 
+                and (ieffect is not None)
+                and (oeffect.name == ieffect.name)): continue
+
+            # New sized stackvar: Typeoverwrite NULL
+            if otype is None and oeffect.size:
+                op = type_overwrite
+                src = nullnode
+                flag = true_str
+                dst = typestackpeek_format%(f"{osize} - i")
                 opstr = "".join([
                     f"for (int i = 0; i < ({oeffect.size}); i++) {{"
                     f"{op}({src}, {dst}, {flag});"
@@ -600,51 +603,46 @@ class Instruction:
                 out.emit(opstr)
                 continue
 
-            # Check if there's type info
-            if typ := oeffect.type_annotation:
-                for op in typ.ops:
-                    match op.src:
-                        case TypeSrcLiteral(literal=valstr):
-                            if valstr == "NULL":
-                                src = "(_Py_TYPENODE_t *)_Py_TYPENODE_NULLROOT"
-                                flag = "true"
-                            else:
-                                src = f"(_Py_TYPENODE_t *)_Py_TYPENODE_MAKE_ROOT((_Py_TYPENODE_t)&{valstr})"
-                                flag = "true"
-                        case TypeSrcStackInput(name=valstr):
-                            assert valstr in need_to_declare
-                            assert oeffect.name not in self.unmoved_names
-                            src = valstr
-                            flag = "false"
-                        case TypeSrcConst(index=idx):
-                            src = f"(_Py_TYPENODE_t *)TYPECONST_GET({idx})"
-                            flag = "true"
-                        case TypeSrcLocals(index=idx):
-                            src = f"TYPELOCALS_GET({idx})"
-                            flag = "false"
-                        case _:
-                            typing.assert_never(op.src)
+            assert not oeffect.size, f"Typed sized stackvar not supported!"
 
-                    opstr = f"{op.op}({src}, {dst}, {flag})"
-                    if oeffect.cond:
-                        out.emit(f"if ({oeffect.cond}) {{ {opstr}; }}")
-                    else:
-                        out.emit(f"{opstr};")
+            # New stackvar: Typeoverwrite NULL
+            if otype is None:
+                typ_op = type_overwrite
+                src = nullnode
+                flag = true_str
+                opstr = f"{typ_op}({src}, {dst}, {flag})"
+                if oeffect.cond:
+                    out.emit(f"if ({oeffect.cond}) {{ {opstr}; }}")
+                else:
+                    out.emit(f"{opstr};")
                 continue
 
-            # Don't touch unmoved stack vars
-            if oeffect.name in self.unmoved_names:
-                continue
+            # Literal/Input/Locals/Consts Typeoverwrite/Typeset
+            for op in otype.ops:
+                match op.src:
+                    case TypeSrcLiteral(literal=valstr):
+                        if valstr == null:
+                            src = nullnode
+                            flag = true_str
+                        else:
+                            src = literal_root_format%valstr
+                            flag = true_str
+                    case TypeSrcStackInput(name=src):
+                        flag = false_str
+                    case TypeSrcConst(index=idx):
+                        src = typeconstsget_format%idx
+                        flag = true_str
+                    case TypeSrcLocals(index=idx):
+                        src = typelocalsget_format%idx
+                        flag = false_str
+                    case _:
+                        typing.assert_never(op.src)
 
-            # Just output null
-            typ_op = "TYPE_OVERWRITE"
-            src = "(_Py_TYPENODE_t *)_Py_TYPENODE_NULLROOT"
-            flag = "true"
-            opstr = f"{typ_op}({src}, {dst}, {flag})"
-            if oeffect.cond:
-                out.emit(f"if ({oeffect.cond}) {{ {opstr}; }}")
-            else:
-                out.emit(f"{opstr};")
+                opstr = f"{op.op}({src}, {dst}, {flag})"
+                if oeffect.cond:
+                    out.emit(f"if ({oeffect.cond}) {{ {opstr}; }}")
+                else:
+                    out.emit(f"{opstr};")
 
 
 InstructionOrCacheEffect = Instruction | parser.CacheEffect

--- a/Tools/cases_generator/generate_cases.py
+++ b/Tools/cases_generator/generate_cases.py
@@ -592,7 +592,6 @@ class Instruction:
             for op in otype.ops:
                 match op.src:
                     case TypeSrcLiteral(literal=valstr):
-                        print(self.name)
                         if valstr == null:
                             src = nullnode
                             flag = true_str

--- a/Tools/cases_generator/parser.py
+++ b/Tools/cases_generator/parser.py
@@ -131,7 +131,7 @@ class CacheEffect(Node):
 @dataclass
 class LocalEffect(Node):
     index: str
-    value: TypeSrc
+    value: TypeSrcLiteral | TypeSrcStackInput
 
 
 @dataclass


### PR DESCRIPTION
1. Behaviour of the generated code is identical to the current branch
2. Refactored to be more explicit in how it is following the spec
3. De-duplicated the logic on which variables to declare (before u had to modify two places)
4. Fixed TYPE_SET to do nothing if src and dst are the same tree to fix possible reference loops